### PR TITLE
Update Stack Exchange logo

### DIFF
--- a/images/svg/stackexchange.svg
+++ b/images/svg/stackexchange.svg
@@ -1,6 +1,1 @@
-<svg
-xmlns="http://www.w3.org/2000/svg"
-aria-label="Stack Exchange" role="img"
-viewBox="0 0 512 512"><rect width="512" height="512"
-fill="#fff"
-rx="15%"/><linearGradient id="a" x2="0" y2="60%"><stop stop-color="#91d8f4"/><stop stop-color="#1e5397" offset="99%"/></linearGradient><path fill="url(#a)" d="M156 71q-50 0-50 50v16h300v-16q0-50-50-50m-250 86v60h300v-60m-300 82v60h300v-60m0 80H106v16q0 50 50 50h123v65l65-65h12q50 0 50-50"/></svg>
+<svg xmlns="http://www.w3.org/2000/svg" aria-label="Stack Exchange" role="img" viewBox="0 0 512 512"><rect width="512" height="512" fill="#fff" rx="15%"/><path fill="#91d8f4" d="m156,71q-50,0 -50,50v16h300v-16q0,-50 -50,-50"/><path fill="#4ca2da" d="m106,157v60h300v-60"/><path fill="#376db6" d="m106,239v60h300v-60"/><path fill="#1e5397" d="M406,319H106v16q0,50 50,50h123v65l65,-65h12q50,0 50,-50"/></svg>


### PR DESCRIPTION
Fixes #167.

Remove the linearGradient from the Stack Exchange logo. Gradients are against the project’s rules.
This also updates the logo to the new logo from Stack Exchange which can be seen at
https://stackoverflow.com/company/logos