### PR TITLE
Shrinks adobe.svg

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,7 +300,7 @@ Say thanks!
 <td>Ubiquiti<br><img src="https://edent.github.io/SuperTinyIcons/images/svg/ubiquiti.svg" width="125" title="Ubiquiti"/><br>558 Bytes</td>
 </tr>
 <tr>
-<td>Adobe<br><img src="https://edent.github.io/SuperTinyIcons/images/svg/adobe.svg" width="125" title="Adobe"/><br>260 Bytes</td>
+<td>Adobe<br><img src="https://edent.github.io/SuperTinyIcons/images/svg/adobe.svg" width="125" title="Adobe"/><br>238 Bytes</td>
 <td>Homekit<br><img src="https://edent.github.io/SuperTinyIcons/images/svg/homekit.svg" width="125" title="Homekit"/><br>821 Bytes</td>
 <td>Pixelfed<br><img src="https://edent.github.io/SuperTinyIcons/images/svg/pixelfed.svg" width="125" title="Pixelfed"/><br>989 Bytes</td>
 <td>Samsung<br><img src="https://edent.github.io/SuperTinyIcons/images/svg/samsung.svg" width="125" title="Samsung"/><br>1023 Bytes</td>

--- a/images/svg/adobe.svg
+++ b/images/svg/adobe.svg
@@ -3,4 +3,4 @@ aria-label="Adobe" role="img"
 viewBox="0 0 512 512"><rect
 width="512" height="512"
 fill="#ed2224"
-rx="15%"/><path fill="#fff" d="M296 120l114 272V120H296m-194 0v272l114-272H102m105 217h52l23 55h46l-73-173-48 118"/></svg>
+rx="15%"/><path fill="#fff" d="M296,120h114v272zm-80,0h-114v272zm39,99l-48,118h52l23,55h46z"/></svg>


### PR DESCRIPTION
Uses z command in `path` to close shapes,
reducing size of `d` attribute.