### PR TITLE
Smaller microsoft.svg

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,7 +296,7 @@ Say thanks!
 <td>RedHat<br><img src="https://edent.github.io/SuperTinyIcons/images/svg/redhat.svg" width="125" title="RedHat"/><br>549 Bytes</td>
 <td>CentOS<br><img src="https://edent.github.io/SuperTinyIcons/images/svg/centos.svg" width="125" title="CentOS"/><br>761 Bytes</td>
 <td>Git<br><img src="https://edent.github.io/SuperTinyIcons/images/svg/git.svg" width="125" title="git"/><br>467 Bytes</td>
-<td>Microsoft<br><img src="https://edent.github.io/SuperTinyIcons/images/svg/microsoft.svg" width="125" title="Microsoft"/><br>403 Bytes</td>
+<td>Microsoft<br><img src="https://edent.github.io/SuperTinyIcons/images/svg/microsoft.svg" width="125" title="Microsoft"/><br>347 Bytes</td>
 <td>Grafana<br><img src="https://edent.github.io/SuperTinyIcons/images/svg/grafana.svg" width="125" title="Grafana"/><br>972 Bytes</td>
 <td>Ubiquiti<br><img src="https://edent.github.io/SuperTinyIcons/images/svg/ubiquiti.svg" width="125" title="Ubiquiti"/><br>558 Bytes</td>
 </tr>

--- a/images/svg/microsoft.svg
+++ b/images/svg/microsoft.svg
@@ -3,12 +3,8 @@ aria-label="Microsoft" role="img"
 viewBox="0 0 512 512"><rect
 width="512" height="512"
 rx="15%"
-fill="#fff"/><rect
-x="75" y="75" width="171" height="171"
-fill="#f25022"/><rect
-x="266" y="75" width="171" height="171"
-fill="#7fba00"/><rect
-x="75" y="266" width="171" height="171"
-fill="#00a4ef"/><rect
-x="266" y="266" width="171" height="171"
-fill="#ffb900"/></svg>
+fill="#fff"/><path
+d="M75 75v171h171v-171z" fill="#f25022"/><path
+d="M266 75v171h171v-171z" fill="#7fba00"/><path
+d="M75 266v171h171v-171z" fill="#00a4ef"/><path
+d="M266 266v171h171v-171z" fill="#ffb900"/></svg>


### PR DESCRIPTION
By using <path> elements instead of <rect> elements, microsoft.svg can be made 56 bytes smaller