### PR TITLE
Reduced size of thisamericanlife.svg

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,7 +311,7 @@ Say thanks!
 <tr>
 <td>Uphold<br><img src="https://edent.github.io/SuperTinyIcons/images/svg/uphold.svg" width="125" title="Uphold"/><br>819 Bytes</td>
 <td>CoinPot<br><img src="https://edent.github.io/SuperTinyIcons/images/svg/coinpot.svg" width="125" title="CoinPot"/><br>739 Bytes</td>
-<td>This American Life<br><img src="https://edent.github.io/SuperTinyIcons/images/svg/thisamericanlife.svg" width="125" title="This American Life"/><br>443 Bytes</td>
+<td>This American Life<br><img src="https://edent.github.io/SuperTinyIcons/images/svg/thisamericanlife.svg" width="125" title="This American Life"/><br>309 Bytes</td>
 <td>WHATWG<br><img src="https://edent.github.io/SuperTinyIcons/images/svg/whatwg.svg" width="125" title="WHATWG"/><br>463 Bytes</td>
 </tr>
 </table>

--- a/images/svg/thisamericanlife.svg
+++ b/images/svg/thisamericanlife.svg
@@ -3,4 +3,5 @@ aria-label="This American Life" role="img"
 viewBox="0 0 512 512"><rect
 width="512" height="512"
 rx="15%"
-fill="#fff"/><g fill="#ed0017"><rect x="90" y="170" width="117" height="98"/><rect x="247.7" y="170" width="175.3" height="29.25" /><rect x="247.7" y="239" width="175.3" height="29.25" /><rect x="90" y="307" width="333" height="29.25" /><polygon points="208,335.6 208,420.4 278.5,335.6"/></g></svg>
+fill="#fff"/><path
+d="M90 170v98h117v-98zM247.7 170v29.25h175.3v-29.25zM247.7 239v29.25h175.3v-29.25zM208 420.4V336.25H90V307H423v29.25H278z" fill="#ed0017"/></svg>


### PR DESCRIPTION
By replacing a collection of <rect> elements and a <polygon> element with a single <path>, the file size of thisamericanlife.svg can be reduced from 443 bytes to 309 bytes.