### PR TITLE
Shrink adobe.svg by 1 byte

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,7 +303,7 @@ Say thanks!
 <td>Ubiquiti<br><img src="https://edent.github.io/SuperTinyIcons/images/svg/ubiquiti.svg" width="125" title="Ubiquiti"/><br>558 Bytes</td>
 </tr>
 <tr>
-<td>Adobe<br><img src="https://edent.github.io/SuperTinyIcons/images/svg/adobe.svg" width="125" title="Adobe"/><br>238 Bytes</td>
+<td>Adobe<br><img src="https://edent.github.io/SuperTinyIcons/images/svg/adobe.svg" width="125" title="Adobe"/><br>237 Bytes</td>
 <td>Homekit<br><img src="https://edent.github.io/SuperTinyIcons/images/svg/homekit.svg" width="125" title="Homekit"/><br>821 Bytes</td>
 <td>Pixelfed<br><img src="https://edent.github.io/SuperTinyIcons/images/svg/pixelfed.svg" width="125" title="Pixelfed"/><br>989 Bytes</td>
 <td>Samsung<br><img src="https://edent.github.io/SuperTinyIcons/images/svg/samsung.svg" width="125" title="Samsung"/><br>1023 Bytes</td>

--- a/images/svg/adobe.svg
+++ b/images/svg/adobe.svg
@@ -3,4 +3,4 @@ aria-label="Adobe" role="img"
 viewBox="0 0 512 512"><rect
 width="512" height="512"
 fill="#ed2224"
-rx="15%"/><path fill="#fff" d="M296,120h114v272zm-80,0h-114v272zm39,99l-48,118h52l23,55h46z"/></svg>
+rx="15%"/><path fill="#fff" d="M296,120h114v272zm-80,0h-114v272zm39,99-48,118h52l23,55h46z"/></svg>


### PR DESCRIPTION
@edent Per [SVG Cleaner](https://github.com/RazrFalcon/svgcleaner-gui), the removed `l` is unnecessary.