### PR TITLE
Shrink amazon_s3.svg by 118 bytes

### DIFF
--- a/README.md
+++ b/README.md
@@ -471,7 +471,7 @@ Say thanks!
 <td>Raspberry Pi<br><img src="https://edent.github.io/SuperTinyIcons/images/svg/raspberry_pi.svg" width="125" title="Raspberry Pi" /><br>1010 Bytes</td>
 <td>Printer<br><img src="https://edent.github.io/SuperTinyIcons/images/svg/print.svg" width="125" title="Printer" /><br>567 Bytes</td>
 <td>Uber<br><img src="https://edent.github.io/SuperTinyIcons/images/svg/uber.svg" width="125" title="Uber" /><br>864 Bytes</td>
-<td>Amazon <abbr title="Simple Storage Service">S3</abbr><br><img src="https://edent.github.io/SuperTinyIcons/images/svg/amazon_s3.svg" width="125" title="Amazon S3"/><br>766 Bytes</td>
+<td>Amazon <abbr title="Simple Storage Service">S3</abbr><br><img src="https://edent.github.io/SuperTinyIcons/images/svg/amazon_s3.svg" width="125" title="Amazon S3"/><br>648 Bytes</td>
 </tr>
 <tr>
 <td>Ansible<br><img src="https://edent.github.io/SuperTinyIcons/images/svg/ansible.svg" width="125" title="Ansible"/><br>430 Bytes</td>

--- a/images/svg/amazon_s3.svg
+++ b/images/svg/amazon_s3.svg
@@ -3,4 +3,4 @@ aria-label="Amazon Simple Storage Service" role="img"
 viewBox="0 0 512 512"><rect
 width="512" height="512"
 rx="15%"
-fill="#fff"/><path fill="#e05243" d="M259.7 348.2l-137 32.7V130.6l137 32v185.6"/><path fill="#8c3123" d="M256 348.6l133.3 32.3.1-.3V131l-.1-.3L256 163v185.7"/><g fill="#e05243"><path id="a" d="M256 64v96.8l58 14.4V93l-58-29zm133.3 66.6v250.3l25.6-12.8V143.4l-25.6-12.8zM256 207.7v97l58-7.5V215l-58-7.3zm58 129.1l-58 14.4V448l58-29v-82.2z"/></g><use xlink:href="#a" transform="rotate(180 256 256)" fill="#8c3123"/><path fill="#5e1f18" d="M314 175.2l-58 10.7-58-10.7 57.9-15.1 58.3 15.1"/><path fill="#f2b0a9" d="M314 336.8l-58-10.7-58 10.7 57.9 16.1 58.3-16.1"/></svg>
+fill="#fff"/><path fill="#e05243" d="M260 348l-137 33V131l137 32z"/><path fill="#8c3123" d="M256 349l133 32V131l-133 32v186"/><g fill="#e05243"><path id="a" d="M256 64v97l58 14V93zm133 67v250l26-13V143zm-133 77v97l58-8v-82zm58 129l-58 14v97l58-29z"/></g><use fill="#8c3123" transform="rotate(180 256 256)" xlink:href="#a"/><path fill="#5e1f18" d="M314 175l-58 11-58-11 58-15 58 15"/><path fill="#f2b0a9" d="M314 337l-58-11-58 11 58 16 58-16"/></svg>


### PR DESCRIPTION
@edent Path & whitespace optimization by [SVG Cleaner](https://github.com/RazrFalcon/svgcleaner-gui), then [SVGOMG](https://jakearchibald.github.io/svgomg/).
_N.B.:  Notice the conversion of many `M`→ `m`.  IDK why, but I got rendering errors on multiple viewers with the uppercase versions, & the optimizers lowercased them, anyway._