### PR TITLE
Minified Centos to 743 bytes

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,7 +301,7 @@ Say thanks!
 </tr>
 <tr>
 <td>RedHat<br><img src="https://edent.github.io/SuperTinyIcons/images/svg/redhat.svg" width="125" title="RedHat"/><br>549 Bytes</td>
-<td>CentOS<br><img src="https://edent.github.io/SuperTinyIcons/images/svg/centos.svg" width="125" title="CentOS"/><br>761 Bytes</td>
+<td>CentOS<br><img src="https://edent.github.io/SuperTinyIcons/images/svg/centos.svg" width="125" title="CentOS"/><br>743 Bytes</td>
 <td>Git<br><img src="https://edent.github.io/SuperTinyIcons/images/svg/git.svg" width="125" title="git"/><br>467 Bytes</td>
 <td>Microsoft<br><img src="https://edent.github.io/SuperTinyIcons/images/svg/microsoft.svg" width="125" title="Microsoft"/><br>347 Bytes</td>
 <td>Grafana<br><img src="https://edent.github.io/SuperTinyIcons/images/svg/grafana.svg" width="125" title="Grafana"/><br>972 Bytes</td>

--- a/images/svg/centos.svg
+++ b/images/svg/centos.svg
@@ -4,4 +4,5 @@ aria-label="CentOS" role="img"
 viewBox="0 0 512 512"><rect
 width="512" height="512"
 rx="15%"
-fill="#fff"/><g id="g"><rect x="118" y="118" fill="#9ccd2a" width="124" height="124"/><rect x="270" y="118" fill="#932279" width="124" height="124"/><rect x="270" y="270" fill="#efa724" width="124" height="124"/><rect x="118" y="270" fill="#262577" width="124" height="124"/></g><use xlink:href="#g" transform="rotate(225 256 256)"/><path d="M118 270h124v124H118zm152 0h124v124H270zm0-152h124v124H270zm-152 0h124v124H118zm245 226l-87-88 87-88 88 88zM256 236l-88-87 88-88 88 88zM149 344l-88-88 88-88 87 88zm107 107l-88-88 88-87 88 87z" fill="none" stroke="#fff" stroke-width="9"/></svg>
+fill="#fff"/><g id="g"><rect x="118" y="118" fill="#9ccd2a" width="124" height="124"/><rect x="270" y="118" fill="#932279" width="124" height="124"/><rect x="270" y="270" fill="#efa724" width="124" height="124"/><rect x="118" y="270" fill="#262577" width="124" height="124"/></g><use xlink:href="#g" transform="rotate(225 256 256)"/><path fill="none" stroke="#fff" stroke-width="9"
+d="m236 256-87 88-88-88 88-88zm6-14H118V118H242zm0 28V394H118V270zm14-34-88-87 88-88 88 88zm0 40-88 87 88 88 88-88zm14-34V118H394V242zm0 28H394V394H270zm6-14 87 88 88-88-88-88z"/></svg>


### PR DESCRIPTION
Optimized a path in centos.svg. It looks like there might be some off-by-one errors in the path, but I left it the same shape for now. Fixing it in the future should not change the size 