### PR TITLE
Minimized Jacobin to 241 bytes

### DIFF
--- a/README.md
+++ b/README.md
@@ -489,7 +489,7 @@ Say thanks!
 <td>Finder<br><img src="https://edent.github.io/SuperTinyIcons/images/svg/finder.svg" width="125" title="Finder" /><br>780 Bytes</td>
 <td>Roundcube<br><img src="https://edent.github.io/SuperTinyIcons/images/svg/roundcube.svg" width="125" title="Roundcube"/><br>838 Bytes</td>
 <td>Fritz!<br><img src="https://edent.github.io/SuperTinyIcons/images/svg/fritz.svg" width="125" title="Fritz!"/><br>707 Bytes</td>
-<td>Jacobin<br><img src="https://edent.github.io/SuperTinyIcons/images/svg/jacobin.svg" width="125" title="Jacobin Magazine"/><br>245 Bytes</td>
+<td>Jacobin<br><img src="https://edent.github.io/SuperTinyIcons/images/svg/jacobin.svg" width="125" title="Jacobin Magazine"/><br>241 Bytes</td>
 </tr>
 <tr>
 <td>Keskonfai.fr<br><img src="https://edent.github.io/SuperTinyIcons/images/svg/keskonfai.svg" width="125" title="Keskonfai"/><br>700 Bytes</td>

--- a/images/svg/jacobin.svg
+++ b/images/svg/jacobin.svg
@@ -3,4 +3,4 @@ aria-label="Jacobin" role="img"
 viewBox="0 0 512 512"><rect
 width="512" height="512"
 rx="15%"
-fill="#fff"/><path fill="none" stroke="#000" stroke-width="34" d="M166,326a84,84 0 1,0 170,0v-202h-178"/></svg>
+fill="#fff"/><path fill="none" stroke="#000" stroke-width="34" d="m166 326a84 84 0 10170 0V124H158"/></svg>


### PR DESCRIPTION
The path in jacobin.svg was unoptimized, so I shaved off a few bytes