### PR TITLE
Shrank Windows to 252 bytes

### DIFF
--- a/README.md
+++ b/README.md
@@ -441,7 +441,7 @@ Say thanks!
 <td>Arch Linux<br><img src="https://edent.github.io/SuperTinyIcons/images/svg/arch_linux.svg" width="125" title="Arch Linux" /><br>425 Bytes</td>
 <td>GNU/Linux<br><img src="https://edent.github.io/SuperTinyIcons/images/svg/linux.svg" width="125" title="Linux" /><br>965 Bytes</td>
 <td>Ubuntu<br><img src="https://edent.github.io/SuperTinyIcons/images/svg/ubuntu.svg" width="125" title="Ubuntu" /><br>455 Bytes</td>
-<td>Windows<br><img src="https://edent.github.io/SuperTinyIcons/images/svg/windows.svg" width="125" title="Microsoft Windows" /><br>270 Bytes</td>
+<td>Windows<br><img src="https://edent.github.io/SuperTinyIcons/images/svg/windows.svg" width="125" title="Microsoft Windows" /><br>252 Bytes</td>
 <td>Elementary OS<br><img src="https://edent.github.io/SuperTinyIcons/images/svg/elementaryos.svg" width="125" title="Elementary OS" /><br>466 Bytes</td>
 </tr>
 <tr>

--- a/images/svg/windows.svg
+++ b/images/svg/windows.svg
@@ -3,4 +3,4 @@ aria-label="Windows" role="img"
 viewBox="0 0 512 512"><rect
 width="512" height="512"
 rx="15%"
-fill="#00adef"/><path fill="#fff" d="M98 145l127-18v123H98m142-125l168-24v148H240M98 263h127v123L98 368m142-104h168v147l-168-24"/></svg>
+fill="#00adef"/><path fill="#fff" d="M98 145V250H225V127m15-2V250H408V101M98 368V263H225V386m15 1V263H408V411"/></svg>


### PR DESCRIPTION
Shrank windows.svg and also fixed an off by one error in the path that resulted in a less than perfect recreation