### PR TITLE
Shrank Yubico to 306 bytes

### DIFF
--- a/README.md
+++ b/README.md
@@ -337,7 +337,7 @@ Say thanks!
 <td>Lock / PGP<br><img src="https://edent.github.io/SuperTinyIcons/images/svg/lock.svg" width="125" title="Lock" /><br>393 Bytes</td>
 <td>LastPass<br><img src="https://edent.github.io/SuperTinyIcons/images/svg/lastpass.svg" width="125" title="LastPass" /><br>297 Bytes</td>
 <td>Symantec<br><img src="https://edent.github.io/SuperTinyIcons/images/svg/symantec.svg" width="125" title="Symantec" /><br>614 Bytes</td>
-<td>Yubico<br><img src="https://edent.github.io/SuperTinyIcons/images/svg/yubico.svg" width="125" title="Yubico" /><br>309 Bytes</td>
+<td>Yubico<br><img src="https://edent.github.io/SuperTinyIcons/images/svg/yubico.svg" width="125" title="Yubico" /><br>306 Bytes</td>
 <td>Keybase<br><img src="https://edent.github.io/SuperTinyIcons/images/svg/keybase.svg" width="125" title="Keybase" /><br>647 Bytes</td>
 </tr>
 <tr>

--- a/images/svg/yubico.svg
+++ b/images/svg/yubico.svg
@@ -3,4 +3,5 @@ aria-label="Yubico" role="img"
 viewBox="0 0 512 512"><rect
 width="512" height="512"
 rx="15%"
-fill="#fff"/><circle cx="256" cy="256" fill="none" r="233" stroke="#98c93c" stroke-width="45"/><path d="m256 260 46-132h68l-114 279h-71l33-77-80-202h69z" fill="#98c93c"/></svg>
+fill="#fff"/><circle cx="256" cy="256" fill="none" r="233" stroke="#98c93c" stroke-width="45"/><path
+d="M256 407H185l33-77-80-202h69l49 132 46-132h68" fill="#98c93c"/></svg>


### PR DESCRIPTION
rearranged path commands to make yubico.svg 3 bytes smaller