### PR TITLE
Shrank Ethereum to 412 bytes

### DIFF
--- a/README.md
+++ b/README.md
@@ -362,7 +362,7 @@ Say thanks!
 <tr>
 <td>PayPal<br><img src="https://edent.github.io/SuperTinyIcons/images/svg/paypal.svg" width="125" title="PayPal" /><br>548 Bytes</td>
 <td>Bitcoin<br><img src="https://edent.github.io/SuperTinyIcons/images/svg/bitcoin.svg" width="125" title="Bitcoin" /><br>529 Bytes</td>
-<td>Ethereum<br><img src="https://edent.github.io/SuperTinyIcons/images/svg/ethereum.svg" width="125" title="Ethereum" /><br>463 Bytes</td>
+<td>Ethereum<br><img src="https://edent.github.io/SuperTinyIcons/images/svg/ethereum.svg" width="125" title="Ethereum" /><br>412 Bytes</td>
 <td>Liberapay<br><img src="https://edent.github.io/SuperTinyIcons/images/svg/liberapay.svg" width="125" title="Liberapay" /><br>565 Bytes</td>
 <td>Ko-Fi<br><img src="https://edent.github.io/SuperTinyIcons/images/svg/ko-fi.svg" width="125" title="Ko-Fi" /><br>421 Bytes</td>
 <td>Flattr<br><img src="https://edent.github.io/SuperTinyIcons/images/svg/flattr.svg" width="125" title="Flattr" /><br>347 Bytes</td>

--- a/images/svg/ethereum.svg
+++ b/images/svg/ethereum.svg
@@ -3,4 +3,9 @@ aria-label="Ethereum" role="img"
 viewBox="0 0 512 512"><rect
 width="512" height="512"
 rx="15%"
-fill="#fff"/><path fill="#3C3C3B" d="M256 362l-21 45 21 62 131-185z"/><path fill="#8C8C8C" d="M256 469V362l-132-78z"/><path fill="#343434" d="M256 41L124 259l132 78 131-78z"/><path fill="#8C8C8C" d="M256 41L124 259l132-60z"/><path fill="#141414" d="M256 337l131-78-131-60z"/><path fill="#393939" d="M124 259l132 78V199z"/></svg>
+fill="#fff"/><path
+fill="#3C3C3B" d="m256 362v107l131-185z"/><path
+fill="#343434" d="m256 41l131 218-131 78-132-78"/><path
+fill="#8C8C8C" d="m256 41v158l-132 60m0 25l132 78v107"/><path
+fill="#141414" d="m256 199v138l131-78"/><path
+fill="#393939" d="m124 259l132-60v138"/></svg>


### PR DESCRIPTION
shaved 51 bytes off of ethereum.svg by optimizing all 5 paths in the file