### PR TITLE
Optimize tiktok.svg

### DIFF
--- a/images/svg/tiktok.svg
+++ b/images/svg/tiktok.svg
@@ -1,5 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
-aria-label="TikTok" role="img"
-viewBox="0 0 512 512"><rect
-rx="15%" height="512" width="512"
-fill="#fff"/><defs><path id="t" d="M219 200a117 117 0 1 0 101 115v-128a150 150 0 0 0 88 28v-63a88 88 0 0 1-88-88h-64v252a54 54 0 1 1-37-51z" style="mix-blend-mode:multiply"/></defs><use href="#t" fill="#f05" x="18" y="15"/><use href="#t" fill="#0ee"/></svg>
+<svg xmlns="http://www.w3.org/2000/svg" aria-label="TikTok" viewBox="0 0 512 512"><rect rx="15%" height="512" width="512" fill="#fff"/><style>*{mix-blend-mode:multiply}</style><path fill="#ff004f" d="M237 215a117 117 0 1 0 100.6 115.4v-128a150 150 0 0 0 88 28v-63a88 88 0 0 1-88-88H274V331a53.5 53.5 0 1 1-37-51z"/><path d="M219 200a117 117 0 1 0 100.6 115.4v-128a150 150 0 0 0 88 28v-63a88 88 0 0 1-88-88H256V316a53.5 53.5 0 1 1-37-51z" fill="#00f2ea"/></svg>

--- a/images/svg/tiktok.svg
+++ b/images/svg/tiktok.svg
@@ -1,1 +1,6 @@
-<svg xmlns="http://www.w3.org/2000/svg" aria-label="TikTok" viewBox="0 0 512 512"><rect rx="15%" height="512" width="512" fill="#fff"/><style>*{mix-blend-mode:multiply}</style><path fill="#ff004f" d="M237 215a117 117 0 1 0 100.6 115.4v-128a150 150 0 0 0 88 28v-63a88 88 0 0 1-88-88H274V331a53.5 53.5 0 1 1-37-51z"/><path d="M219 200a117 117 0 1 0 100.6 115.4v-128a150 150 0 0 0 88 28v-63a88 88 0 0 1-88-88H256V316a53.5 53.5 0 1 1-37-51z" fill="#00f2ea"/></svg>
+<svg xmlns="http://www.w3.org/2000/svg"
+aria-label="TikTok" role="img"
+viewBox="0 0 512 512"><rect
+width="512" height="512"
+rx="15%"
+fill="#fff"/><style>*{mix-blend-mode:multiply}</style><path fill="#ff004f" d="M237 215a117 117 0 1 0 100.6 115.4v-128a150 150 0 0 0 88 28v-63a88 88 0 0 1-88-88H274V331a53.5 53.5 0 1 1-37-51z"/><path d="M219 200a117 117 0 1 0 100.6 115.4v-128a150 150 0 0 0 88 28v-63a88 88 0 0 1-88-88H256V316a53.5 53.5 0 1 1-37-51z" fill="#00f2ea"/></svg>


### PR DESCRIPTION
This PR runs `tiktok.svg` through [SVGO](https://github.com/svg/svgo) to conserve 56 bytes.