### PR TITLE
Vegetarian logo updated Fixes-#813

### DIFF
--- a/images/svg/vegetarian-new.svg
+++ b/images/svg/vegetarian-new.svg
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:svg="http://www.w3.org/2000/svg" xmlns="http://www.w3.org/2000/svg" version="1.0" width="340pt" height="362pt" viewBox="0 0 340 362">
+  <title>Vegetarian mark</title>
+  <metadata>
+    <rdf:RDF>
+      <cc:Work rdf:about="">
+        <dc:format>
+          image/svg+xml
+        </dc:format>
+        <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+        <dc:title>
+          Vegetarian mark
+        </dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+<!--Green border circle-->
+  <circle cx="170" cy="181" r="145" stroke="#017f00" stroke-width="10" fill="none"/>
+<!--Main logo adjusted-->
+  <g transform="matrix(0.05,0.0,0.0,-0.06,85,295)" style="fill:#000000;stroke:none">
+    <path d="m 3190,3550 c -80,-21 -249,-59 -375,-84 -321,-63 -372,-82 -515,-188 -203,-151 -345,-443 -344,-708 1,-101 16,-173 33,-154 4,5 18,34 30,64 61,147 238,371 389,492 77,62 232,123 232,91 0,-11 -53,-77 -116,-143 -59,-63 -79,-89 -190,-250 -115,-169 -265,-471 -366,-740 -98,-261 -170,-469 -218,-625 -81,-267 -154,-478 -167,-482 -16,-6 -60,137 -152,492 -143,556 -204,747 -350,1095 -100,237 -232,427 -500,718 -147,161 -356,315 -482,357 -82,28 -89,14 -27,-55 292,-329 461,-573 640,-920 151,-295 255,-588 444,-1260 48,-172 154,-610 188,-780 38,-189 80,-374 91,-403 4,-9 19,-21 34,-25 34,-9 198,-9 233,0 52,15 62,56 134,528 48,319 89,510 171,795 139,486 287,842 377,900 13,8 77,24 144,35 260,43 469,158 617,341 99,122 125,212 150,512 13,159 21,204 51,299 19,62 32,118 30,125 -7,18 -23,16 -186,-27 z" style="fill:#017f00"/>
+  </g>
+</svg>


### PR DESCRIPTION
-Fixes #813 

- Preview of the updated logo:- 

![Screenshot 2024-10-01 233020](https://github.com/user-attachments/assets/f2574cd8-952c-4f1a-bd46-9166d0e68d74)
