### PR TITLE
Update HTML5 logo to comply with current SVG standards

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Super Tiny Icons
 
-Under 1KB each! Super Tiny Web Icons are minuscule SVG versions of your favourite logos. There are currently 403 icons and the average size is _under_ 522 bytes!
+Under 1KB each! Super Tiny Web Icons are minuscule SVG versions of your favourite logos. There are currently 404 icons and the average size is _under_ 520 bytes!
 
 The logos have a 512x512 viewbox, they will fit in a circle with radius 256. They will scale up and down to suit your needs.
 
@@ -270,7 +270,7 @@ If you do not follow the instructions, your contribution will be marked as spam 
 <td>Heroku<br><img src="https://edent.github.io/SuperTinyIcons/images/svg/heroku.svg" width="100" title="Heroku"><br>435 bytes</td>
 <td>Homekit<br><img src="https://edent.github.io/SuperTinyIcons/images/svg/homekit.svg" width="100" title="Homekit"><br>732 bytes</td>
 <td>HP<br><img src="https://edent.github.io/SuperTinyIcons/images/svg/hp.svg" width="100" title="HP"><br>471 bytes</td>
-<td>HTML5<br><img src="https://edent.github.io/SuperTinyIcons/images/svg/html5.svg" width="100" title="HTML5"><br>397 bytes</td>
+<td>HTML5<br><img src="https://edent.github.io/SuperTinyIcons/images/svg/html5.svg" width="100" title="HTML5"><br>435 bytes</td>
 </tr>
 
 <tr>

--- a/images/svg/html5.svg
+++ b/images/svg/html5.svg
@@ -1,3 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 aria-label="HTML5" role="img"
-viewBox="0 0 512 512"><path fill="#e34f26" d="M71 460L30 0h451l-41 460-185 52"/><path fill="#ef652a" d="M256 472l149-41 35-394H256"/><path fill="#ebebeb" d="M255 414 139 382l-7-89h56l4 45 63 17Zm1-149H129L114 94H256v56H176l5 58h75Z"/><path fill="#fff" d="M255 208v57h70l-7 73-63 17v59l116-32 16-174zm0-114v56h137l5-56z"/></svg>
+viewBox="0 0 512 512"><path
+d="m0 0H512V512H0"
+fill="#fff"/><path fill="#e34f26" d="M71 460L30 0h451l-41 460-185 52"/><path fill="#ef652a" d="M256 472l149-41 35-394H256"/><path fill="#ebebeb" d="M255 414 139 382l-7-89h56l4 45 63 17Zm1-149H129L114 94H256v56H176l5 58h75Z"/><path fill="#fff" d="M255 208v57h70l-7 73-63 17v59l116-32 16-174zm0-114v56h137l5-56z"/></svg>


### PR DESCRIPTION
 Fix #820 
- Add required white background template path as per project guidelines

Thank you for your contribution! Before sending this Pull Request, please confirm the following:

* [x] You have read [the contributing guidelines](https://github.com/edent/SuperTinyIcons/blob/master/CONTRIBUTING.md)
* [x] The icon's size is *under* 1,024 Bytes (435 bytes)
* [x] The layout of the SVG looks like this *including* newlines
```svg
<svg xmlns="http://www.w3.org/2000/svg"
aria-label="HTML5" role="img"
viewBox="0 0 512 512"><path
d="m0 0H512V512H0"
fill="#fff"/><path fill="#e34f26" d="M71 460L30 0h451l-41 460-185 52"/><path fill="#ef652a" d="M256 472l149-41 35-394H256"/><path fill="#ebebeb" d="M255 414 139 382l-7-89h56l4 45 63 17Zm1-149H129L114 94H256v56H176l5 58h75Z"/><path fill="#fff" d="M255 208v57h70l-7 73-63 17v59l116-32 16-174zm0-114v56h137l5-56z"/></svg>