### PR TITLE
Change Fedora URL to brand guidelines page.

### DIFF
--- a/images/reference/fedora.url
+++ b/images/reference/fedora.url
@@ -1,1 +1,1 @@
-https://fedoraproject.org
+https://docs.fedoraproject.org/en-US/project/brand/


### PR DESCRIPTION
The URL to the Fedora Brand Guidlines (added in #955) is incorrect.

This MR changes the URL to the correct page.

<sup>Related to #757</sup>