### PR TITLE
Change Linux Foundation URL to brand guidelines page.

### DIFF
--- a/images/reference/linux-foundation.url
+++ b/images/reference/linux-foundation.url
@@ -1,1 +1,1 @@
-https://www.linuxfoundation.org/
+https://www.linuxfoundation.org/brand-guidelines


### PR DESCRIPTION
The URL to the Linux Foundation Brand Guidlines (added in #968) is incorrect.

This MR changes the URL to the correct page.
