### PR TITLE
Updated Kotlin logo

### DIFF
--- a/images/reference/kotlin.svg
+++ b/images/reference/kotlin.svg
@@ -1,34 +1,19 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- Generator: Adobe Illustrator 19.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<!-- Generator: Adobe Illustrator 24.1.2, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
 <svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-	 viewBox="0 0 60 60" style="enable-background:new 0 0 60 60;" xml:space="preserve">
-<g>
-
-		<linearGradient id="XMLID_3_" gradientUnits="userSpaceOnUse" x1="15.9594" y1="-13.0143" x2="44.3068" y2="15.3332" gradientTransform="matrix(1 0 0 -1 0 61)">
-		<stop  offset="9.677000e-02" style="stop-color:#0095D5"/>
-		<stop  offset="0.3007" style="stop-color:#238AD9"/>
-		<stop  offset="0.6211" style="stop-color:#557BDE"/>
-		<stop  offset="0.8643" style="stop-color:#7472E2"/>
-		<stop  offset="1" style="stop-color:#806EE3"/>
-	</linearGradient>
-	<polygon id="XMLID_2_" style="fill:url(#XMLID_3_);" points="0,60 30.1,29.9 60,60 	"/>
-
-		<linearGradient id="SVGID_1_" gradientUnits="userSpaceOnUse" x1="4.2092" y1="48.9409" x2="20.6734" y2="65.405" gradientTransform="matrix(1 0 0 -1 0 61)">
-		<stop  offset="0.1183" style="stop-color:#0095D5"/>
-		<stop  offset="0.4178" style="stop-color:#3C83DC"/>
-		<stop  offset="0.6962" style="stop-color:#6D74E1"/>
-		<stop  offset="0.8333" style="stop-color:#806EE3"/>
-	</linearGradient>
-	<polygon style="fill:url(#SVGID_1_);" points="0,0 30.1,0 0,32.5 	"/>
-
-		<linearGradient id="SVGID_2_" gradientUnits="userSpaceOnUse" x1="-10.1017" y1="5.8362" x2="45.7315" y2="61.6694" gradientTransform="matrix(1 0 0 -1 0 61)">
-		<stop  offset="0.1075" style="stop-color:#C757BC"/>
-		<stop  offset="0.2138" style="stop-color:#D0609A"/>
-		<stop  offset="0.4254" style="stop-color:#E1725C"/>
-		<stop  offset="0.6048" style="stop-color:#EE7E2F"/>
-		<stop  offset="0.743" style="stop-color:#F58613"/>
-		<stop  offset="0.8232" style="stop-color:#F88909"/>
-	</linearGradient>
-	<polygon style="fill:url(#SVGID_2_);" points="30.1,0 0,31.7 0,60 30.1,29.9 60,0 	"/>
+	 viewBox="0 0 500 500" style="enable-background:new 0 0 500 500;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:url(#SVGID_1_);}
+</style>
+<g id="Logotypes">
+	<g>
+		
+			<linearGradient id="SVGID_1_" gradientUnits="userSpaceOnUse" x1="500.0035" y1="579.1058" x2="-9.653803e-02" y2="1079.2058" gradientTransform="matrix(0.9998 0 0 0.9998 9.651873e-02 -578.99)">
+			<stop  offset="3.435144e-03" style="stop-color:#E44857"/>
+			<stop  offset="0.4689" style="stop-color:#C711E1"/>
+			<stop  offset="1" style="stop-color:#7F52FF"/>
+		</linearGradient>
+		<polygon class="st0" points="500,500 0,500 0,0 500,0 250,250 		"/>
+	</g>
 </g>
 </svg>

--- a/images/svg/kotlin.svg
+++ b/images/svg/kotlin.svg
@@ -2,4 +2,4 @@
 aria-label="Kotlin" role="img"
 viewBox="0 0 512 512"><path
 d="m0 0H512V512H0"
-fill="#27282c"/><path fill="#09d" d="M410 410H102V102h154v154"/><path fill="#f80" d="M410 102H256L102 267v143"/></svg>
+fill="#000"/><linearGradient id="a" y1="1"><stop offset="0" style="stop-color:#7F52FF"/><stop offset="0.53" style="stop-color:#C711E1"/><stop offset="1" style="stop-color:#E44857"/></linearGradient><path fill="url(#a)" d="M120 120H392L256 256 392 392H120Z"/></svg>


### PR DESCRIPTION
Thank you for your contribution!  Before sending this Pull Request, please confirm the following:

* [x] I have read [the contributing guidelines](https://github.com/edent/SuperTinyIcons/blob/master/CONTRIBUTING.md)
* [x] I have run `python check.py` and received a ✅
* [x] The icon's size is *under* 1,024 Bytes
* [x] The layout of the SVG looks like this *including* newlines
```svg
<svg xmlns="http://www.w3.org/2000/svg"
aria-label="..." role="img"
viewBox="0 0 512 512"><path
d="m0 0H512V512H0"
fill="#fff"/> ... </svg>
```

Closes #1049 
File size: 382 bytes

Had some nerdy fun sorting out the gradient transform and then releasing that reversing it reduced the file size even more! 🤓 
